### PR TITLE
Generering av jacoco-rapport og laster resultatet opp på github

### DIFF
--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -42,7 +43,24 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: true
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml
+
+      - name: Upload Report
+        uses: 'actions/upload-artifact@v4'
+        with:
+          name: jacoco-report
+          path: ${{ github.workspace }}/target/site/jacoco/
+          retention-days: 2
+
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.7.0
+        with:
+          paths: ${{ github.workspace }}/target/site/jacoco/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          title: Code Coverage
 
       - uses: nais/docker-build-push@v0
         id: docker-push

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,7 @@
                             </execution>
                             <execution>
                                 <id>report</id>
+                                <phase>verify</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>


### PR DESCRIPTION
Bygger med jacoco, laster resultatet opp på gha og bruker en jacoco-reporter gha jobb for å kommentere på resultatet

![image](https://github.com/user-attachments/assets/b1d24254-8081-4b41-8575-47d8c872591b)
