### PR TITLE
Flytt konfig fra vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,17 @@ psql -U postgres
 CREATE DATABASE "familie-ba-infotrygd-feed";
 ```
 
+### Test av InfotrygdFeedController med STS-token i preprod
+For å teste InfotrygdFeedController så trenger man å få lagd ett STS-token.
+
+1. Gå til swagger for [security-token-service](https://security-token-service.dev.adeo.no/swagger-ui/index.html?configUrl=/api/api-doc/swagger-config#/System%20OIDC%20Token/postOIDCToken)
+2. Velg security-token-service.dev.adeo.no fra dropdown med navn Servers
+3. Fyll inn brukernavn og passord i Authorize-feltet. Brukernavnet og passordet finner man i [vault for familie-integrasjoner](https://vault.adeo.no/ui/vault/secrets/kv%2Fpreprod%2Ffss/show/familie-integrasjoner/teamfamilie) som CREDENTIAL_USERNAME og CREDEENTIAL_PASSWORD.
+4. Kjør POST /rest/v1/sts/token med client_credentials og openid
+5. I swagger for [familie-ba-infotrygd-feed](https://familie-ba-infotrygd-feed.intern.dev.nav.no/swagger-ui/index.html#/infotrygd-feed-controller/feed), trykk Authorize. Skriv inn ```Bearer <token>``` 
+
+
+
+
 ## Kontaktinformasjon
 For NAV-interne kan henvendelser om applikasjonen rettes til #team-familie på slack. Ellers kan man opprette et issue her på github.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,3 +32,5 @@ management:
     exposure.include: info, health, metrics, prometheus
     base-path: "/internal"
   metrics.export.prometheus.enabled: true
+
+GYLDIG_SERVICE_BRUKER: srvfamilie-ks-opps,srvInfot


### PR DESCRIPTION
I kanalen #infotrygd-feed så ble det meldt om at man fikk 401 unauthorized ved lesing av feed de siste 3 dagene.

GYLDIGE_SERVICE_BRUKER lå i vault, men etter flytting til distroless så blir ikke vault-config lest inn ved oppstart. Akkurat denne konfigen er ikke noe man trenger i en secret, så flytter den heller til koden.

Testet at man først fikk 401 uten config og så 200 OK etter config i preprod