### PR TITLE
Spring security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <felles-kontrakter.version>4.0_20260420090252_0eaf8ff</felles-kontrakter.version>
         <felles.version>4.20260428145828_c16a1d8</felles.version>
         <springdoc.version>3.0.3</springdoc.version>
-        <token-validation-spring.version>6.0.6</token-validation-spring.version>
+        <mock-oauth2-server.version>3.0.1</mock-oauth2-server.version>
         <spring.vault.version>4.0.2</spring.vault.version>
         <spring.cloud.version>5.0.1</spring.cloud.version>
     </properties>
@@ -158,20 +158,21 @@
             <artifactId>sikkerhet</artifactId>
             <version>${felles.version}</version>
         </dependency>
+
+        <!-- Spring Security OAuth2 -->
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
-            <artifactId>sikkerhet-token-support</artifactId>
+            <artifactId>sikkerhet-spring-security</artifactId>
             <version>${felles.version}</version>
         </dependency>
         <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-validation-spring</artifactId>
-            <version>${token-validation-spring.version}</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.security</groupId>
-            <artifactId>token-validation-spring-test</artifactId>
-            <version>${token-validation-spring.version}</version>
+            <artifactId>mock-oauth2-server</artifactId>
+            <version>${mock-oauth2-server.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/ApplicationConfig.kt
@@ -2,23 +2,18 @@ package no.nav.familie.ba.infotrygd.feed.config
 
 import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.filter.LogFilter
-import no.nav.familie.sikkerhet.context.FamilieFellesNavTokenSupportKonfigurasjon
-import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
 import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.Import
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootConfiguration
 @ConfigurationPropertiesScan
 @EnableJpaRepositories(ApplicationConfig.PAKKENAVN)
-@EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
 @ComponentScan(ApplicationConfig.PAKKENAVN)
-@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)
 class ApplicationConfig {
     @Bean
     fun logFilter(): FilterRegistrationBean<LogFilter> {

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/AzureDecoder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/AzureDecoder.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.ba.infotrygd.feed.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtClaimValidator
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtValidators
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.stereotype.Component
+
+/**
+ * JwtDecoder for Azure AD tokens.
+ * Brukes for service-to-service og ansatt-autentisering.
+ */
+@Component
+class AzureDecoder(
+    @param:Value("\${AZURE_OPENID_CONFIG_ISSUER}") private val azureIssuer: String,
+    @param:Value("\${AZURE_APP_CLIENT_ID}") private val azureClientId: String,
+) : JwtDecoder {
+    private val delegate by lazy {
+        val decoder = NimbusJwtDecoder.withIssuerLocation(azureIssuer).build()
+        decoder.setJwtValidator(
+            DelegatingOAuth2TokenValidator(
+                JwtValidators.createDefaultWithIssuer(azureIssuer),
+                JwtClaimValidator<Collection<String>>("aud") { audiences ->
+                    azureClientId in audiences
+                },
+            ),
+        )
+        decoder
+    }
+
+    override fun decode(token: String?): Jwt? = delegate.decode(token)
+}

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/AzureDecoder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/AzureDecoder.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.infotrygd.feed.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtAudienceValidator
 import org.springframework.security.oauth2.jwt.JwtClaimValidator
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtValidators
@@ -23,13 +24,12 @@ class AzureDecoder(
         decoder.setJwtValidator(
             DelegatingOAuth2TokenValidator(
                 JwtValidators.createDefaultWithIssuer(azureIssuer),
-                JwtClaimValidator<Collection<String>>("aud") { audiences ->
-                    azureClientId in audiences
-                },
-            ),
+                JwtAudienceValidator(azureClientId),
+            )
         )
         decoder
     }
+
 
     override fun decode(token: String?): Jwt? = delegate.decode(token)
 }

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/AzureDecoder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/AzureDecoder.kt
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtAudienceValidator
-import org.springframework.security.oauth2.jwt.JwtClaimValidator
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtValidators
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
@@ -25,11 +24,10 @@ class AzureDecoder(
             DelegatingOAuth2TokenValidator(
                 JwtValidators.createDefaultWithIssuer(azureIssuer),
                 JwtAudienceValidator(azureClientId),
-            )
+            ),
         )
         decoder
     }
-
 
     override fun decode(token: String?): Jwt? = delegate.decode(token)
 }

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityConfig.kt
@@ -1,0 +1,73 @@
+package no.nav.familie.ba.infotrygd.feed.config
+
+import no.nav.familie.sikkerhet.context.FamilieFellesSpringSecurityKonfigurasjon
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.core.Ordered.LOWEST_PRECEDENCE
+import org.springframework.core.annotation.Order
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@Import(FamilieFellesSpringSecurityKonfigurasjon::class)
+class SecurityConfig(
+    private val azureDecoder: AzureDecoder,
+    private val stsDecoder: StsDecoder,
+) {
+    /**
+     * Filter chain for Azure AD endpoints - krever Azure AD token.
+     * Høyere prioritet (@Order(1)) slik at denne matcher før default.
+     */
+    @Bean
+    @Order(1)
+    fun azureSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            securityMatcher(
+                "/api/barnetrygd/v1/feedazure",
+                "/api/barnetrygd/v1/feedazure",
+                "/api/barnetrygd/v1/feed/*/opprettet",
+            )
+
+            authorizeHttpRequests {
+                authorize(anyRequest, authenticated)
+            }
+
+            oauth2ResourceServer {
+                jwt { jwtDecoder = azureDecoder }
+            }
+            csrf { disable() }
+        }
+
+        return http.build()
+    }
+
+    /**
+     * Default filter chain - krever STS token (legacy).
+     * Laveste prioritet (@Order(LOWEST_PRECEDENCE)) slik at den matcher alt annet.
+     */
+    @Bean
+    @Order(LOWEST_PRECEDENCE)
+    fun defaultSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            authorizeHttpRequests {
+                authorize("/internal/**", permitAll)
+                authorize("/swagger-ui/**", permitAll)
+                authorize("/v3/api-docs/**", permitAll)
+
+                authorize(anyRequest, authenticated)
+            }
+            oauth2ResourceServer {
+                jwt { jwtDecoder = stsDecoder }
+            }
+            csrf { disable() }
+        }
+
+        return http.build()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityConfig.kt
@@ -32,6 +32,12 @@ class SecurityConfig(
                 "/api/barnetrygd/v1/feedazure",
                 "/api/barnetrygd/v1/feedazure",
                 "/api/barnetrygd/v1/feed/*/opprettet",
+<<<<<<< Updated upstream
+=======
+                "/api/barnetrygd/v1/feed/foedselsmelding",
+                "/api/barnetrygd/v1/feed/vedtaksmelding",
+                "/api/barnetrygd/v1/feed/startbehandlingsmelding",
+>>>>>>> Stashed changes
             )
 
             authorizeHttpRequests {

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityConfig.kt
@@ -32,12 +32,9 @@ class SecurityConfig(
                 "/api/barnetrygd/v1/feedazure",
                 "/api/barnetrygd/v1/feedazure",
                 "/api/barnetrygd/v1/feed/*/opprettet",
-<<<<<<< Updated upstream
-=======
                 "/api/barnetrygd/v1/feed/foedselsmelding",
                 "/api/barnetrygd/v1/feed/vedtaksmelding",
                 "/api/barnetrygd/v1/feed/startbehandlingsmelding",
->>>>>>> Stashed changes
             )
 
             authorizeHttpRequests {

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtAudienceValidator
-import org.springframework.security.oauth2.jwt.JwtClaimValidator
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtValidators
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.infotrygd.feed.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtAudienceValidator
 import org.springframework.security.oauth2.jwt.JwtClaimValidator
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtValidators
@@ -19,23 +20,14 @@ class StsDecoder(
     @param:Value("\${GYLDIG_SERVICE_BRUKER}") private val gyldigServiceBruker: String?,
 ) : JwtDecoder {
     private val delegate by lazy {
-        require(!stsIssuer.isNullOrBlank()) { "GYLDIG_SERVICE_BRUKER må være satt" }
+        require(!stsIssuer.isNullOrBlank()) { "STS_ISSUER må være satt" }
         require(!gyldigServiceBruker.isNullOrBlank()) { "GYLDIG_SERVICE_BRUKER må være satt" }
-
-        val gyldigeServiceBrukere =
-            gyldigServiceBruker
-                .split(",")
-                .map { it.trim() }
-                .filter { it.isNotEmpty() }
-        require(gyldigeServiceBrukere.isNotEmpty()) { "STS_CLIENT_ID må være satt" }
 
         val decoder = NimbusJwtDecoder.withIssuerLocation(stsIssuer).build()
         decoder.setJwtValidator(
             DelegatingOAuth2TokenValidator(
                 JwtValidators.createDefaultWithIssuer(stsIssuer),
-                JwtClaimValidator<Collection<String>>("aud") { audiences ->
-                    gyldigeServiceBrukere.any { it in audiences }
-                },
+                JwtAudienceValidator(gyldigServiceBruker),
             ),
         )
         decoder

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
@@ -2,8 +2,11 @@ package no.nav.familie.ba.infotrygd.feed.config
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes
+import org.springframework.security.oauth2.core.OAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
 import org.springframework.security.oauth2.jwt.Jwt
-import org.springframework.security.oauth2.jwt.JwtAudienceValidator
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtValidators
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
@@ -16,20 +19,50 @@ import org.springframework.stereotype.Component
 @Component
 class StsDecoder(
     @param:Value("\${STS_ISSUER}") private val stsIssuer: String?,
-    @param:Value("\${GYLDIG_SERVICE_BRUKER}") private val gyldigServiceBruker: String?,
+    @param:Value("\${GYLDIG_SERVICE_BRUKER}") private val gyldigServiceBrukere: String?,
 ) : JwtDecoder {
     private val delegate by lazy {
         require(!stsIssuer.isNullOrBlank()) { "STS_ISSUER må være satt" }
-        require(!gyldigServiceBruker.isNullOrBlank()) { "GYLDIG_SERVICE_BRUKER må være satt" }
+        require(!gyldigServiceBrukere.isNullOrBlank()) { "GYLDIG_SERVICE_BRUKER må være satt" }
 
         val decoder = NimbusJwtDecoder.withIssuerLocation(stsIssuer).build()
         decoder.setJwtValidator(
             DelegatingOAuth2TokenValidator(
                 JwtValidators.createDefaultWithIssuer(stsIssuer),
-                JwtAudienceValidator(gyldigServiceBruker),
+                audienceAnyValidator(gyldigServiceBrukere),
             ),
         )
         decoder
+    }
+
+    /**
+     * GYLDIG_SERVICE_BRUKER er ofte en liste, for å støtte at audiencene i tokenet matcher minst én av service-brukerne i
+     * lista må vi lage en custom validator
+     */
+    private fun audienceAnyValidator(gyldigeServiceBrukere: String): OAuth2TokenValidator<Jwt> {
+        val allowedAudiences =
+            gyldigeServiceBrukere
+                .split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .toSet()
+
+        return OAuth2TokenValidator { jwt ->
+            val tokenAudiences = jwt.audience.toSet()
+            val hasMatch = tokenAudiences.any { it in allowedAudiences }
+
+            if (hasMatch) {
+                OAuth2TokenValidatorResult.success()
+            } else {
+                OAuth2TokenValidatorResult.failure(
+                    OAuth2Error(
+                        OAuth2ErrorCodes.INVALID_TOKEN,
+                        "Token audience matcher ingen gyldige servicebrukere",
+                        null,
+                    ),
+                )
+            }
+        }
     }
 
     override fun decode(token: String?): Jwt? = delegate.decode(token)

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ba.infotrygd.feed.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtClaimValidator
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtValidators
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.stereotype.Component
+
+/**
+ * JwtDecoder for legacy STS tokens.
+ * Brukes for eldre systemintegrasjoner som fortsatt bruker STS.
+ */
+@Component
+class StsDecoder(
+    @param:Value("\${STS_ISSUER}") private val stsIssuer: String?,
+    @param:Value("\${GYLDIG_SERVICE_BRUKER}") private val gyldigServiceBruker: String?,
+) : JwtDecoder {
+    private val delegate by lazy {
+        require(!stsIssuer.isNullOrBlank()) { "STS_ISSUER må være satt" }
+        require(!gyldigServiceBruker.isNullOrBlank()) { "STS_CLIENT_ID må være satt" }
+
+        val decoder = NimbusJwtDecoder.withIssuerLocation(stsIssuer).build()
+        decoder.setJwtValidator(
+            DelegatingOAuth2TokenValidator(
+                JwtValidators.createDefaultWithIssuer(stsIssuer),
+                JwtClaimValidator<Collection<String>>("aud") { audiences ->
+                    gyldigServiceBruker in audiences
+                },
+            ),
+        )
+        decoder
+    }
+
+    override fun decode(token: String?): Jwt? = delegate.decode(token)
+}

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/config/StsDecoder.kt
@@ -19,15 +19,22 @@ class StsDecoder(
     @param:Value("\${GYLDIG_SERVICE_BRUKER}") private val gyldigServiceBruker: String?,
 ) : JwtDecoder {
     private val delegate by lazy {
-        require(!stsIssuer.isNullOrBlank()) { "STS_ISSUER må være satt" }
-        require(!gyldigServiceBruker.isNullOrBlank()) { "STS_CLIENT_ID må være satt" }
+        require(!stsIssuer.isNullOrBlank()) { "GYLDIG_SERVICE_BRUKER må være satt" }
+        require(!gyldigServiceBruker.isNullOrBlank()) { "GYLDIG_SERVICE_BRUKER må være satt" }
+
+        val gyldigeServiceBrukere =
+            gyldigServiceBruker
+                .split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+        require(gyldigeServiceBrukere.isNotEmpty()) { "STS_CLIENT_ID må være satt" }
 
         val decoder = NimbusJwtDecoder.withIssuerLocation(stsIssuer).build()
         decoder.setJwtValidator(
             DelegatingOAuth2TokenValidator(
                 JwtValidators.createDefaultWithIssuer(stsIssuer),
                 JwtClaimValidator<Collection<String>>("aud") { audiences ->
-                    gyldigServiceBruker in audiences
+                    gyldigeServiceBrukere.any { it in audiences }
                 },
             ),
         )

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/rest/InfotrygdFeedController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/rest/InfotrygdFeedController.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ba.infotrygd.feed.rest.dto.erAlfanummerisk
 import no.nav.familie.ba.infotrygd.feed.rest.dto.konverterTilFeedMeldingDto
 import no.nav.familie.ba.infotrygd.feed.service.InfotrygdFeedService
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/barnetrygd")
-@ProtectedWithClaims(issuer = "sts")
 class InfotrygdFeedController(
     private val infotrygdFeedService: InfotrygdFeedService,
 ) {
@@ -59,7 +57,6 @@ class InfotrygdFeedController(
         description = "Henter hendelser med sekvensId større enn sistLesteSekvensId.",
     )
     @GetMapping("/v1/feedazure", produces = ["application/json; charset=us-ascii"])
-    @ProtectedWithClaims(issuer = "azuread")
     fun feedAzure(
         @Parameter(description = "Sist leste sekvensnummer.", required = true, example = "0")
         @RequestParam("sistLesteSekvensId")
@@ -82,7 +79,6 @@ class InfotrygdFeedController(
             )
 
     @PostMapping("/v1/feed/{type}/opprettet", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @ProtectedWithClaims(issuer = "azuread")
     fun feedOpprettet(
         @PathVariable type: Type,
         @RequestBody fnr: String,

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/rest/OpprettFeedController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/rest/OpprettFeedController.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.infotrygd.feed.rest.dto.VedtakDto
 import no.nav.familie.ba.infotrygd.feed.rest.dto.erAlfanummerisk
 import no.nav.familie.ba.infotrygd.feed.service.InfotrygdFeedService
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -20,7 +19,6 @@ import java.time.LocalDate
 
 @RestController()
 @RequestMapping("/api/barnetrygd")
-@ProtectedWithClaims(issuer = "azuread")
 class OpprettFeedController(
     private val infotrygdFeedService: InfotrygdFeedService,
 ) {

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/rest/TestDataController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/feed/rest/TestDataController.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.infotrygd.feed.rest.dto.StartBehandlingDto
 import no.nav.familie.ba.infotrygd.feed.rest.dto.Type
 import no.nav.familie.ba.infotrygd.feed.rest.dto.VedtakDto
 import no.nav.familie.ba.infotrygd.feed.service.InfotrygdFeedService
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -17,7 +16,6 @@ import java.time.LocalDate
 
 @RestController
 @Profile("!prod")
-@ProtectedWithClaims(issuer = "sts")
 class TestDataController(
     val infotrygdFeedService: InfotrygdFeedService,
 ) {

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -1,11 +1,4 @@
-no.nav.security.jwt:
-  issuer.sts:
-    discoveryurl: https://security-token-service.nais.preprod.local/rest/v1/sts/.well-known/openid-configuration
-    accepted_audience: ${GYLDIG_SERVICE_BRUKER}
-  issuer.azuread:
-    discoveryurl: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
-    proxyurl: http://webproxy-nais.nav.no:8088
+STS_ISSUER:  https://security-token-service.nais.preprod.local/rest/v1/sts/.well-known/openid-configuration
 
 spring:
   datasource:

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -1,4 +1,4 @@
-STS_ISSUER:  https://security-token-service.nais.preprod.local/rest/v1/sts/.well-known/openid-configuration
+STS_ISSUER:  https://security-token-service.nais.preprod.local
 
 spring:
   datasource:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,11 +1,4 @@
-no.nav.security.jwt:
-  issuer.sts:
-    discoveryurl: https://security-token-service.nais.adeo.no/rest/v1/sts/.well-known/openid-configuration
-    accepted_audience: ${GYLDIG_SERVICE_BRUKER}
-  issuer.azuread:
-    discoveryurl: https://login.microsoftonline.com/navno.onmicrosoft.com/v2.0/.well-known/openid-configuration
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
-    proxyurl: http://webproxy-nais.nav.no:8088
+STS_ISSUER:  https://security-token-service.nais.adeo.no/rest/v1/sts/.well-known/openid-configuration
 
 spring:
   datasource:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,4 +1,4 @@
-STS_ISSUER:  https://security-token-service.nais.adeo.no/rest/v1/sts/.well-known/openid-configuration
+STS_ISSUER:  https://security-token-service.nais.adeo.no
 
 spring:
   datasource:

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/DevLauncher.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/DevLauncher.kt
@@ -1,15 +1,15 @@
 package no.nav.familie.ba.infotrygd
 
-import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import no.nav.familie.ba.infotrygd.feed.config.MockOAuth2ServerInitializer
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 
 @SpringBootApplication(scanBasePackages = ["no.nav.familie.ba.infotrygd.feed"])
-@EnableMockOAuth2Server
 class DevLauncher
 
 fun main(args: Array<String>) {
     val springApp = SpringApplication(DevLauncher::class.java)
     springApp.setAdditionalProfiles("dev")
+    springApp.addInitializers(MockOAuth2ServerInitializer())
     springApp.run(*args)
 }

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/JwtTokenTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/JwtTokenTestUtil.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.ba.infotrygd.feed.config
+
+import no.nav.security.mock.oauth2.MockOAuth2Server
+
+object JwtTokenTestUtil {
+    fun lagStsToken(
+        mockOAuth2Server: MockOAuth2Server,
+        subject: String = "srvfamilie-ba-infotrygd-feed",
+        audience: String = "aud-localhost",
+        tilleggsClaims: Map<String, Any> = emptyMap(),
+    ): String =
+        mockOAuth2Server
+            .issueToken(
+                issuerId = "sts",
+                subject = subject,
+                audience = audience,
+                claims = tilleggsClaims,
+            ).serialize()
+
+    fun lagAzureAdToken(
+        mockOAuth2Server: MockOAuth2Server,
+        subject: String = "test-user@nav.no",
+        audience: String = "aud-localhost",
+        groups: List<String> = emptyList(),
+        tilleggsClaims: Map<String, Any> = emptyMap(),
+    ): String {
+        val claims =
+            mapOf(
+                "groups" to groups,
+                "preferred_username" to subject,
+            ) + tilleggsClaims
+
+        return mockOAuth2Server
+            .issueToken(
+                issuerId = "azuread",
+                subject = subject,
+                audience = audience,
+                claims = claims,
+            ).serialize()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/JwtTokenTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/JwtTokenTestUtil.kt
@@ -6,8 +6,15 @@ object JwtTokenTestUtil {
     fun lagStsToken(
         mockOAuth2Server: MockOAuth2Server,
         subject: String = "srvfamilie-ba-infotrygd-feed",
-        audience: String = "aud-localhost",
-        tilleggsClaims: Map<String, Any> = emptyMap(),
+        audience: String? = null,
+        tilleggsClaims: Map<String, Any> =
+            mapOf(
+                "aud" to
+                    listOf(
+                        "aud1",
+                        "aud-localhost",
+                    ),
+            ),
     ): String =
         mockOAuth2Server
             .issueToken(

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/MockOAuth2ServerInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/MockOAuth2ServerInitializer.kt
@@ -23,7 +23,7 @@ class MockOAuth2ServerInitializer : ApplicationContextInitializer<ConfigurableAp
         val properties =
             mapOf<String, Any>(
                 "STS_ISSUER" to server.issuerUrl("sts").toString(),
-                "GYLDIG_SERVICE_BRUKER" to "aud-localhost",
+                "GYLDIG_SERVICE_BRUKER" to "aud1,aud2,aud3",
                 "AZURE_OPENID_CONFIG_ISSUER" to server.issuerUrl("azuread").toString(),
                 "AZURE_APP_CLIENT_ID" to "aud-localhost",
             )

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/MockOAuth2ServerInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/MockOAuth2ServerInitializer.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ba.infotrygd.feed.config
+
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.MapPropertySource
+
+class MockOAuth2ServerInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    companion object {
+        private val server: MockOAuth2Server by lazy {
+            MockOAuth2Server().also { server ->
+                server.start()
+                Runtime.getRuntime().addShutdownHook(
+                    Thread {
+                        server.shutdown()
+                    },
+                )
+            }
+        }
+    }
+
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+        val properties =
+            mapOf<String, Any>(
+                "STS_ISSUER" to server.issuerUrl("sts").toString(),
+                "GYLDIG_SERVICE_BRUKER" to "aud-localhost",
+                "AZURE_OPENID_CONFIG_ISSUER" to server.issuerUrl("azuread").toString(),
+                "AZURE_APP_CLIENT_ID" to "aud-localhost",
+            )
+
+        applicationContext.environment.propertySources.addFirst(
+            MapPropertySource("mockOAuth2Server", properties),
+        )
+
+        applicationContext.beanFactory.registerSingleton("mockOAuth2Server", server)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityIntegrationTest.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.servlet.client.RestTestClient
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev")
@@ -22,12 +22,12 @@ class SecurityIntegrationTest {
     @Autowired
     private lateinit var mockOAuth2Server: MockOAuth2Server
 
-    private lateinit var webTestClient: WebTestClient
+    private lateinit var restTestClient: RestTestClient
 
     @BeforeEach
     fun setup() {
-        webTestClient =
-            WebTestClient
+        restTestClient =
+            RestTestClient
                 .bindToServer()
                 .baseUrl("http://localhost:$port")
                 .build()
@@ -37,7 +37,7 @@ class SecurityIntegrationTest {
     inner class OffentligeEndepunkter {
         @Test
         fun `skal tillate tilgang til health uten token`() {
-            webTestClient
+            restTestClient
                 .get()
                 .uri("/internal/health")
                 .exchange()
@@ -47,7 +47,7 @@ class SecurityIntegrationTest {
 
         @Test
         fun `skal tillate tilgang til swagger uten token`() {
-            webTestClient
+            restTestClient
                 .get()
                 .uri("/swagger-ui/index.html")
                 .exchange()
@@ -60,7 +60,7 @@ class SecurityIntegrationTest {
     inner class StsEndepunkter {
         @Test
         fun `skal avvise feed uten token`() {
-            webTestClient
+            restTestClient
                 .get()
                 .uri("/api/barnetrygd/v1/feed?sistLesteSekvensId=0")
                 .exchange()
@@ -73,7 +73,7 @@ class SecurityIntegrationTest {
             val token = JwtTokenTestUtil.lagStsToken(mockOAuth2Server)
 
             val status =
-                webTestClient
+                restTestClient
                     .get()
                     .uri("/api/barnetrygd/v1/feed?sistLesteSekvensId=0")
                     .header("Authorization", "Bearer $token")
@@ -88,7 +88,7 @@ class SecurityIntegrationTest {
         fun `skal avvise Azure AD-token på STS endpoint`() {
             val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
 
-            webTestClient
+            restTestClient
                 .get()
                 .uri("/api/barnetrygd/v1/feed?sistLesteSekvensId=0")
                 .header("Authorization", "Bearer $token")
@@ -104,7 +104,7 @@ class SecurityIntegrationTest {
         fun `skal avvise STS-token på Azure AD endpoint`() {
             val token = JwtTokenTestUtil.lagStsToken(mockOAuth2Server)
 
-            webTestClient
+            restTestClient
                 .get()
                 .uri("/api/barnetrygd/v1/feedazure?sistLesteSekvensId=0")
                 .header("Authorization", "Bearer $token")
@@ -118,15 +118,13 @@ class SecurityIntegrationTest {
             val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
 
             val status =
-                webTestClient
+                restTestClient
                     .get()
                     .uri("/api/barnetrygd/v1/feedazure?sistLesteSekvensId=0")
                     .header("Authorization", "Bearer $token")
                     .exchange()
-                    .returnResult()
-                    .status
-
-            assertFalse(status.is4xxClientError, "status var $status, forventet ikke 4xx")
+                    .expectStatus()
+                    .isOk
         }
 
         @Test
@@ -134,16 +132,14 @@ class SecurityIntegrationTest {
             val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
 
             val status =
-                webTestClient
+                restTestClient
                     .post()
                     .uri("/api/barnetrygd/v1/feed/BA_Foedsel_v1/opprettet")
                     .header("Authorization", "Bearer $token")
-                    .bodyValue("12345678901")
+                    .body("12345678901")
                     .exchange()
-                    .returnResult()
-                    .status
-
-            assertFalse(status.is4xxClientError, "status var $status, forventet ikke 4xx")
+                    .expectStatus()
+                    .isOk
         }
 
         @Test

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityIntegrationTest.kt
@@ -1,0 +1,275 @@
+package no.nav.familie.ba.infotrygd.feed.config
+
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("dev")
+@ContextConfiguration(initializers = [MockOAuth2ServerInitializer::class])
+class SecurityIntegrationTest {
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Autowired
+    private lateinit var mockOAuth2Server: MockOAuth2Server
+
+    private lateinit var webTestClient: WebTestClient
+
+    @BeforeEach
+    fun setup() {
+        webTestClient =
+            WebTestClient
+                .bindToServer()
+                .baseUrl("http://localhost:$port")
+                .build()
+    }
+
+    @Nested
+    inner class OffentligeEndepunkter {
+        @Test
+        fun `skal tillate tilgang til health uten token`() {
+            webTestClient
+                .get()
+                .uri("/internal/health")
+                .exchange()
+                .expectStatus()
+                .isOk
+        }
+
+        @Test
+        fun `skal tillate tilgang til swagger uten token`() {
+            webTestClient
+                .get()
+                .uri("/swagger-ui/index.html")
+                .exchange()
+                .expectStatus()
+                .isOk
+        }
+    }
+
+    @Nested
+    inner class StsEndepunkter {
+        @Test
+        fun `skal avvise feed uten token`() {
+            webTestClient
+                .get()
+                .uri("/api/barnetrygd/v1/feed?sistLesteSekvensId=0")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+
+        @Test
+        fun `skal akseptere STS-token på feed endpoint`() {
+            val token = JwtTokenTestUtil.lagStsToken(mockOAuth2Server)
+
+            val status =
+                webTestClient
+                    .get()
+                    .uri("/api/barnetrygd/v1/feed?sistLesteSekvensId=0")
+                    .header("Authorization", "Bearer $token")
+                    .exchange()
+                    .returnResult()
+                    .status
+
+            assertFalse(status.is4xxClientError, "status var $status, forventet ikke 4xx")
+        }
+
+        @Test
+        fun `skal avvise Azure AD-token på STS endpoint`() {
+            val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
+
+            webTestClient
+                .get()
+                .uri("/api/barnetrygd/v1/feed?sistLesteSekvensId=0")
+                .header("Authorization", "Bearer $token")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+    }
+
+    @Nested
+    inner class AzureAdEndepunkter {
+        @Test
+        fun `skal avvise STS-token på Azure AD endpoint`() {
+            val token = JwtTokenTestUtil.lagStsToken(mockOAuth2Server)
+
+            webTestClient
+                .get()
+                .uri("/api/barnetrygd/v1/feedazure?sistLesteSekvensId=0")
+                .header("Authorization", "Bearer $token")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+
+        @Test
+        fun `skal akseptere Azure AD-token på feedazure endpoint`() {
+            val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
+
+            val status =
+                webTestClient
+                    .get()
+                    .uri("/api/barnetrygd/v1/feedazure?sistLesteSekvensId=0")
+                    .header("Authorization", "Bearer $token")
+                    .exchange()
+                    .returnResult()
+                    .status
+
+            assertFalse(status.is4xxClientError, "status var $status, forventet ikke 4xx")
+        }
+
+        @Test
+        fun `skal akseptere Azure AD-token på opprettet endpoint`() {
+            val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
+
+            val status =
+                webTestClient
+                    .post()
+                    .uri("/api/barnetrygd/v1/feed/BA_Foedsel_v1/opprettet")
+                    .header("Authorization", "Bearer $token")
+                    .bodyValue("12345678901")
+                    .exchange()
+                    .returnResult()
+                    .status
+
+            assertFalse(status.is4xxClientError, "status var $status, forventet ikke 4xx")
+        }
+
+        @Test
+        fun `skal avvise foedselsmelding uten token`() {
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/foedselsmelding")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrBarn": "12345678901"}""")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+
+        @Test
+        fun `skal akseptere Azure AD-token på foedselsmelding endpoint`() {
+            val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
+
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/foedselsmelding")
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrBarn": "12345678901"}""")
+                .exchange()
+                .expectStatus()
+                .isCreated
+        }
+
+        @Test
+        fun `skal avvise STS-token på foedselsmelding endpoint`() {
+            val token = JwtTokenTestUtil.lagStsToken(mockOAuth2Server)
+
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/foedselsmelding")
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrBarn": "12345678901"}""")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+
+        @Test
+        fun `skal avvise vedtaksmelding uten token`() {
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/vedtaksmelding")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrStoenadsmottaker": "12345678901", "datoStartNyBa": "2024-01-01"}""")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+
+        @Test
+        fun `skal akseptere Azure AD-token på vedtaksmelding endpoint`() {
+            val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
+
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/vedtaksmelding")
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrStoenadsmottaker": "12345678901", "datoStartNyBa": "2024-01-01"}""")
+                .exchange()
+                .expectStatus()
+                .isCreated
+        }
+
+        @Test
+        fun `skal avvise STS-token på vedtaksmelding endpoint`() {
+            val token = JwtTokenTestUtil.lagStsToken(mockOAuth2Server)
+
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/vedtaksmelding")
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrStoenadsmottaker": "12345678901", "datoStartNyBa": "2024-01-01"}""")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+
+        @Test
+        fun `skal avvise startbehandlingsmelding uten token`() {
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/startbehandlingsmelding")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrStoenadsmottaker": "12345678901"}""")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+
+        @Test
+        fun `skal akseptere Azure AD-token på startbehandlingsmelding endpoint`() {
+            val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
+
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/startbehandlingsmelding")
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrStoenadsmottaker": "12345678901"}""")
+                .exchange()
+                .expectStatus()
+                .isCreated
+        }
+
+        @Test
+        fun `skal avvise STS-token på startbehandlingsmelding endpoint`() {
+            val token = JwtTokenTestUtil.lagStsToken(mockOAuth2Server)
+
+            restTestClient
+                .post()
+                .uri("/api/barnetrygd/v1/feed/startbehandlingsmelding")
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .body("""{"fnrStoenadsmottaker": "12345678901"}""")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityTestConfig.kt
@@ -1,6 +1,9 @@
 package no.nav.familie.ba.infotrygd.feed.config
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
 
 @Configuration
+@ContextConfiguration(initializers = [MockOAuth2ServerInitializer::class])
 class SecurityTestConfig
+// TODO se om denne er nødvendig å ha?

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/config/SecurityTestConfig.kt
@@ -1,9 +1,0 @@
-package no.nav.familie.ba.infotrygd.feed.config
-
-import org.springframework.context.annotation.Configuration
-import org.springframework.test.context.ContextConfiguration
-
-@Configuration
-@ContextConfiguration(initializers = [MockOAuth2ServerInitializer::class])
-class SecurityTestConfig
-// TODO se om denne er nødvendig å ha?

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/service/InfotrygdFeedServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/feed/service/InfotrygdFeedServiceIntegrationTest.kt
@@ -1,8 +1,8 @@
 package no.nav.familie.ba.infotrygd.feed.service
 
+import no.nav.familie.ba.infotrygd.feed.config.MockOAuth2ServerInitializer
 import no.nav.familie.ba.infotrygd.feed.database.DbContainerInitializer
 import no.nav.familie.ba.infotrygd.feed.rest.dto.Type
-import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -16,10 +16,9 @@ import java.time.LocalDate
 
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
-@ContextConfiguration(initializers = [DbContainerInitializer::class])
+@ContextConfiguration(initializers = [DbContainerInitializer::class, MockOAuth2ServerInitializer::class])
 @ActiveProfiles("postgres")
 @Tag("integration")
-@EnableMockOAuth2Server
 class InfotrygdFeedServiceIntegrationTest {
     @Autowired
     lateinit var infotrygdFeedService: InfotrygdFeedService

--- a/src/test/resources/application-dev.yaml
+++ b/src/test/resources/application-dev.yaml
@@ -1,6 +1,9 @@
 STS_ISSUER:  http://localhost:${mock-oauth2-server.port}/selvbetjening/.well-known/openid-configuration
 GYLDIG_SERVICE_BRUKER: aud-localhost
 
+AZURE_OPENID_CONFIG_ISSUER: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
+AZURE_APP_CLIENT_ID: aud-localhost
+
 spring:
   jpa:
     show-sql: false

--- a/src/test/resources/application-dev.yaml
+++ b/src/test/resources/application-dev.yaml
@@ -1,10 +1,5 @@
-no.nav.security.jwt:
-  issuer.sts:
-    discoveryurl: http://localhost:${mock-oauth2-server.port}/selvbetjening/.well-known/openid-configuration
-    accepted_audience: aud-localhost
-  issuer.azuread:
-    discoveryurl: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
+STS_ISSUER:  http://localhost:${mock-oauth2-server.port}/selvbetjening/.well-known/openid-configuration
+GYLDIG_SERVICE_BRUKER: aud-localhost
 
 spring:
   jpa:


### PR DESCRIPTION
### 📮 Favro: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-28803

### 💰 Hva skal gjøres, og hvorfor?
Infotrygd hadde problemer med å nå applikasjonen. Har reverta migreringen til spring security og nå rettet opp feilen. 
Denne PRen tar inn igjen den originale koden pluss fiks av STS-token.

Det er altså i utgangspunktet kun den siste commiten som er relevant for PR. 

Problemet med STS besto i feil issuer og at audience-claimet egentlig er en liste som må matche minst ett element i GYLDIG_SYSTEM_BRUKER som også er en liste. 

Forrige PR: https://github.com/navikt/familie-ba-infotrygd-feed/pull/1085
Revert: https://github.com/navikt/familie-ba-infotrygd-feed/pull/1089

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
